### PR TITLE
msm8916-common: Disable dex2oat watchdog

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,3 +1,6 @@
+# Art
+dalvik.vm.dex2oat-flags=--no-watch-dog
+
 # Audio
 tunnel.audio.encode=false
 av.offload.enable=true


### PR DESCRIPTION
Low RAM devices are too slow to compile some very big APKs within the
6 mins limit so we get the "Optimizing apps" dialog on each boot and
dex2oat never completes properly, slowing down the whole system.

Change-Id: I1f3b8c533330a2268f36a2357f2b7d9e2d20c2f8